### PR TITLE
Fix use of slice len vs capacity for keys

### DIFF
--- a/statstash.go
+++ b/statstash.go
@@ -168,7 +168,7 @@ func (s StatImplementation) UpdateBackend(periodStart time.Time, flusher StatsFl
 		return nil // nothing to do
 	}
 
-	bucketKeys := make([]string, len(cfgMap))
+	bucketKeys := make([]string, 0, len(cfgMap))
 	for k := range cfgMap {
 		bucketKeys = append(bucketKeys, k)
 	}


### PR DESCRIPTION
Accidentally set len instead of capacity, so the first few entries were all empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/statstash/5)
<!-- Reviewable:end -->
